### PR TITLE
Add one QuickCheck test.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Char8 as B
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
 import Network.SimpleIRC
+import Test.QuickCheck
 
 botNick :: String
 botNick = "klammeraffe"
@@ -14,23 +15,34 @@ freenode = (mkDefaultConfig "irc.freenode.net" botNick)
                cEvents   = [(Privmsg onPrivmsg)]
            }
 
+openingParens = "([<{\"\'„“‚⟦⟨⟪〚⁅〈⎴⏞⏠❬❰❲❴⦃⦗⧼⸦〈《【〔〖〘"
+closingParens = ")]>}\"\'“”‘⟧⟩⟫〛⁆〉⎵⏟⏡❭❱❳❵⦄⦘⧽⸧〉》】〕〗〙"
 
 generateClosingParens :: B.ByteString -> B.ByteString
 generateClosingParens msg = E.encodeUtf8 (calcParens (E.decodeUtf8 msg) T.empty)
-  where calcParens :: T.Text -> T.Text -> T.Text
-        calcParens msg parenStack
-          | T.null parenStack && T.null msg   = ""
-          | T.null msg                        = T.cons (T.head parenStack) (calcParens msg (T.tail parenStack))
-          | not (T.null parenStack) &&
-            T.head msg == T.head parenStack = calcParens (T.tail msg) (T.tail parenStack)
-          | T.head msg `elem` openingParens   = calcParens (T.tail msg) (T.cons (convertToClosingParen (T.head msg)) parenStack)
-          | T.head msg `elem` closingParens   = ""
-          | otherwise                         = calcParens (T.tail msg) parenStack
-          where openingParens = "([<{\"\'„“‚⟦⟨⟪〚⁅〈⎴⏞⏠❬❰❲❴⦃⦗⧼⸦〈《【〔〖〘"
-                closingParens = ")]>}\"\'“”‘⟧⟩⟫〛⁆〉⎵⏟⏡❭❱❳❵⦄⦘⧽⸧〉》】〕〗〙"
-                convertToClosingParen p = T.index closingParens (fromMaybe 0 (T.findIndex (== p) openingParens))
-                elem :: Char -> T.Text -> Bool
-                elem c str = isJust (T.findIndex (== c) str)
+
+calcParens :: T.Text -> T.Text -> T.Text
+calcParens msg parenStack
+    | T.null parenStack && T.null msg   = ""
+    | T.null msg                        = T.cons (T.head parenStack) (calcParens msg (T.tail parenStack))
+    | not (T.null parenStack) &&
+      T.head msg == T.head parenStack = calcParens (T.tail msg) (T.tail parenStack)
+    | T.head msg `elem` openingParens   = calcParens (T.tail msg) (T.cons (convertToClosingParen (T.head msg)) parenStack)
+    | T.head msg `elem` closingParens   = ""
+    | otherwise                         = calcParens (T.tail msg) parenStack
+    where
+          convertToClosingParen p = T.index closingParens (fromMaybe 0 (T.findIndex (== p) openingParens))
+          elem :: Char -> T.Text -> Bool
+          elem c str = isJust (T.findIndex (== c) str)
+
+prop_AtLeastAsManyClosingParens inp =
+  foldr1 (&&) $ map allParensClosed $ zip (spl openingParens) (spl closingParens)
+    where
+      spl = T.chunksOf 1
+      allParensClosed :: (T.Text, T.Text) -> Bool
+      allParensClosed (l, r) = number l completeStr <= number r completeStr
+      completeStr = inp `T.append` calcParens inp T.empty
+      number c str = T.count c str
 
 onPrivmsg :: EventFunc
 onPrivmsg server msg
@@ -41,5 +53,11 @@ onPrivmsg server msg
         chan  = fromJust $ mChan msg
         reply = generateClosingParens (mMsg msg)
 
+instance Arbitrary T.Text where
+  arbitrary = fmap T.pack $ listOf $ oneof [choose ('a', 'z'), elements "([<{\"\'"]
+    where
+      parens :: String
+      parens = T.unpack openingParens ++ T.unpack closingParens
 
 main = connect freenode False True
+tests = quickCheck prop_AtLeastAsManyClosingParens


### PR DESCRIPTION
Ich hab mal einen QuickCheck-Test gemacht (aka ein bisschen rumgespackt).

Ist allerdings extrem langsam; die Klammerstrings sind Text und mit Text ist es recht schwer, auf Char-Basis zu arbeiten.
Vllt. macht es für die wirklich kurzen Strings, die dieses Programm bearbeitet, wirklich Sinn, alles auf [Char]-Basis zu machen (dann hat man auch keine Unicode-Probleme).
